### PR TITLE
fix(meta tag) ajusta atributos de maximum-scale e user-scalable na meta tag 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
     <meta http-equiv="X-UA-Compatible"
           content="ie=edge">
     <title>Starter F&MD</title>

--- a/resources/html/index.html
+++ b/resources/html/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
     <meta http-equiv="X-UA-Compatible"
           content="ie=edge">
     <title>Starter F&MD</title>


### PR DESCRIPTION
Como frontender, preciso remover o user-scalable=no de dentro da tag <meta> pois ele não permite o zoom não na página, influenciando na acessibilidade no lighthouse. E também preciso ajustar o maximum-scale=1.0 para 5, pois o valor mínimo para as vezes que o usuário consegue dar zoom tem que ser 5, pois isso influencia tambêm na acessibilidade no lighthouse.