### PR TITLE
feat(critical-css): Ajusta gerador do critical-css para public

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,63 +14,38 @@ olhar a
       dominio do site localmente
 
 
-## Novos recursos para utilizar com npm run prod
-####### Add to 16-07-2020
+### Detalhe sobre Environment.js
+`resources/js/environment.js` É o centralizador de informações do projeto, 
+sua criação tem como base para ser utilizado como se fosse o env do laravel,
+com isso é possível automatizar o processo de codificação das páginas html 
+de maneira mais simples. No arquivo fica disponível a customização de seo
+de página, domínio, nome do diretório do .net, definição de páginas html
+existentes no projeto para ser utilizado no critical-css.
 
-O arquivo `environment.js` passa a ser um centralizador de alteração de 
-dados da `resources/html/index.html` para `public/index.html` (semelhante ao env 
-que está no starter-laravel)
 
-No arquivo é possível customizar alguns dados que deveríamos adicionar manualmente, 
-ex: título de página, descrição, gtm, etc...
+### Detalhe sobre Critical-path.js 
+No arquivo `webpack.mix.js` temos as configurações de dimensões de tela e 
+páginas do critical-css, com ajuda do Puppeteer ele faz a leitura de todas as
+classes css e extrai para arquivos separados por página (css) em 
+`public/css/critical/`. 
+Com base nos arquivos css gerado do critical-css, o script 
+`resources/js/critical-path` tem como função pegar o estilo css dos arquivos em
+`public/css/critical/` para adicionar dentro do head das páginas html existentes 
+no `public` projeto. 
+Com esse recurso garantimos uma melhoria de performance do site. 
 
-A propriedade 'domain' é utilizada no critical-css  para executar o build do recurso
+### Detalhe sobre Post-prod.js
+O script `resources/js/post-prod` tem como função pegar os dados PostScripts 
+que estão em `resources/js/environment.js`, e alterar em um novo arquivo na
+`public`.
 
-Dentro de 'postStrings' temos as propriedades a serem customizadas conforme citado
-acima. 
-
-Para implementação dos dois novos recursos ( Critical-css e post-prod ) foi criado
-dois arquivos em que são: `/resources/js/critical-path.js` e `/resources/js/post-prod.js`
-
-### Detalhes sobre `/resources/js/critical-path.js`
-
-O Script faz o uso file system do nodejs que é feito a leitura da 
-`/public/index.html` e da `/public/css/critical/index.css` 
-e fica armazenado em variavéis.  O segundo arquivo foi gerado pelo critical-css que
-está no `webpack.mix.js` que tem como objetivo gerar o css do canvas que está configurado
-em dimensions, assim iremos adicionar o estilo dentro do head da página 
-`(public/index.html)` para ganho de performance de carregamento.
-
-No script localizaremos a string `<!--fmd:criticalPath-->` que será trocada pelo
-conteúdo do css que foi gerado pelo critical-css, depois é gravado pelo file 
-system e é gerado um novo arquivo com a modificação na `/public/index.html`
-
-### Detalhes sobre `/resources/js/post-prod.js`
-
-O Script é semelhante ao de cima, faz a leitura e depois grava com os dados 
-modificados. Sua diferença é a inclusão do arquivo `environment.js` ao script. 
-É executa um foreach no objeto 'postStrings' para localizar o identificador
-que foi incluído na página `/resources/html/index.html` e assim feito a troca de 
-conteúdo que está presente no arquivo `environment.js`.
-
-Portanto é necessário que a string do arquivo `/resources/html/index.html` seja 
-correspondente a propriedade que está criada no arquivo `environment.js`
-
-exemplo: <br>
-`/resources/html/index.html` temos `<title><!--fmd:titlePage--></title>` <br>
-`environment.js` temos `titlePage: 'Starter-LP F&MD',`
-
-O match é feito através do titlePage, caso seja necessário incluir um novo, seguir
-os passos abaixo:
-
-`/resources/html/index.html` criar `<!--fmd:exemploNovo-->` <br>
-`environment.js` criar dentro de postScript `exemploNovo: 'novo conteúdo',`
-
-Para adicionar os novos recursos para `/public/` execute o comando:
-
-`npm run prod`
-
-O comando vai executar o script de produção, critical-path e post-prod
+Para codificação dos scripts foi utilizado o fs do node.js para ler/gravar 
+arquivos, em conjunto utilizamos sistema de 'tags' para localizar onde deve
+ocorrer a gravação do novo conteúdo.
+Para que as alterações do critical-path.js e post-prod.js sejam executadas,
+deve-se utilizar o comando npm run prod ou npm run production. Com isso os
+scripts serão executados e as alterações de conteúdos vão estar presentes 
+nos arquivos htmls que estiver no `public` do projeto.
 
 ### Detalhes sobre `Docker`
 No arquivo Dockerfile é necessário alterar a string `Meu-App-Docker`  para o nome correspondente do projeto. <br>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
     "watch": "npm run development -- --watch",
     "watch-poll": "npm run watch -- --watch-poll",
     "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "npm run prod && npm run critical && npm run post-prod",
-    "critical": "node ./resources/js/critical-path.js",
-    "post-prod": "node ./resources/js/post-prod.js",
-    "prod": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "prod": "npm run production",
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
     "accounting": "^0.4.1",

--- a/resources/js/critical-path.js
+++ b/resources/js/critical-path.js
@@ -2,7 +2,9 @@ const fs = require('fs');
 
 function generateCriticalCSS(pages) {
 
-  if (!pages) {
+  const hasPage = pages && !!pages.length;
+
+  if (!hasPage) {
 
     return;
   }
@@ -33,6 +35,7 @@ function generateCriticalCSS(pages) {
         'property',
         'supports',
       ];
+
       let criticalCssAsString = fs.readFileSync(
           criticalItem.criticalCssPath,
           'utf-8',
@@ -42,7 +45,7 @@ function generateCriticalCSS(pages) {
 
         criticalCssAsString = criticalCssAsString.replace(
             new RegExp(`@${atRulesItem}`, 'g'),
-            `@@${atRulesItem}`,
+            `@@${ atRulesItem }`,
         );
       });
 

--- a/resources/js/critical-path.js
+++ b/resources/js/critical-path.js
@@ -1,30 +1,95 @@
 const fs = require('fs');
 
-const criticalCssPath = new URL(
-    'file:///' + process.cwd() + '/public/css/critical/index.css');
-const criticalCssAsString = fs.readFileSync(criticalCssPath, 'utf8');
-const indexHtmlPath = new URL(
-    'file:///' + process.cwd() + '/public/index.html');
+function generateCriticalCSS(pages) {
 
-fs.readFile(indexHtmlPath, 'utf8', function (error, data) {
+  if (!pages) {
 
-  if (error) {
-
-    return console.log(error);
+    return;
   }
 
-  let critical = data.replace(
-      '<!--fmd:criticalPath-->',
-      `<style>${ criticalCssAsString }</style>`,
-  );
+  const convertedPages = getFilePathsToApplyCritical(pages);
 
-  fs.writeFile(indexHtmlPath, critical, 'utf-8', function (error) {
+  convertedPages.forEach((criticalItem) => {
 
-    if (error) {
+    fs.readFile(criticalItem.pagePath, 'utf8', (error, data) => {
 
-      return console.log(error);
-    }
+      if (error) {
 
-    console.log('Critical path added to the public');
+        console.log(error);
+        return;
+      }
+
+      const atRulesDeclarations = [
+        'charset',
+        'color-profile',
+        'counter-style',
+        'font-face',
+        'font-feature-values',
+        'import',
+        'keyframes',
+        'media',
+        'namespace',
+        'page',
+        'property',
+        'supports',
+      ];
+      let criticalCssAsString = fs.readFileSync(
+          criticalItem.criticalCssPath,
+          'utf-8',
+      );
+
+      atRulesDeclarations.forEach((atRulesItem) => {
+
+        criticalCssAsString = criticalCssAsString.replace(
+            new RegExp(`@${atRulesItem}`, 'g'),
+            `@@${atRulesItem}`,
+        );
+      });
+
+      const critical = data.replace(
+          new RegExp(`<!--fmd:criticalPath-->`, 'g'),
+          `<style>${ criticalCssAsString }</style>`,
+      );
+
+      fs.writeFile(criticalItem.pagePath, critical, 'utf-8', (error) => {
+
+        if (error) {
+
+          console.log(error);
+          return;
+        }
+
+        console.log(` --FMD--\n Critical-Path added to the Page ${
+            criticalItem.namePage } in /public`);
+      });
+    });
   });
-});
+}
+
+function getFilePathsToApplyCritical(pageOptions) {
+
+  const relativePathCssCritical = `file:///${ process.cwd() }/public/css/critical/`;
+  const relativePathPage = `file:///${ process.cwd() }/public/`;
+
+  return pageOptions.map(item => ({
+    criticalCssPath: new URL(`${ relativePathCssCritical }${ item.template }.css`),
+    pagePath: new URL(`${ relativePathPage }${ item.template }.html`),
+    namePage: `${ item.template }`,
+  }));
+
+  /*
+   FMD - Outra maneira de escrever o retorno acima.
+   return pageOptions.map((item) => {
+   return {
+   criticalCssPath: new URL(`${ relativePathCssCritical }${ item.template }.css`),
+   pagePath: new URL(`${ relativePathPage }${ item.template }.html`),
+   namePage: `${ item.template }`,
+   }
+   });
+   */
+}
+
+module.exports = {
+
+  generate: generateCriticalCSS,
+};

--- a/resources/js/post-prod.js
+++ b/resources/js/post-prod.js
@@ -3,7 +3,9 @@ const fs = require('fs');
 
 function generatePostProd(pages) {
 
-  if(!pages) {
+  const hasPage = pages && !!pages.length;
+
+  if (!hasPage) {
 
     return;
   }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -88,7 +88,7 @@ mix
 if (!mix.inProduction()) {
   wpConfig.devtool = 'source-map';
   mix.sourceMaps()
-  // .copyDirectory('resources/images', 'public/images')
+      // .copyDirectory('resources/images', 'public/images')
       .copy('resources/images/**/*', 'public/images')
       .copy('resources/images/icons/favicon.ico', 'public');
 }
@@ -140,11 +140,16 @@ mix
 
       if (mix.inProduction()) {
 
-        mix.copyDirectory('resources/html', 'public');
+        repositionTagsProduction();
         postProd.generate(environment.pages);
         criticalPath.generate(environment.pages);
       }
     });
+
+function repositionTagsProduction() {
+
+  mix.copyDirectory('resources/html', 'public');
+}
 
 /*
  |--------------------------------------------------------------------------
@@ -170,14 +175,3 @@ mix.browserSync({
   },
 });
 
-if(environment.folder){
-  mix
-      .copyDirectory('public/css', environment.folder + '/wwwroot/css')
-      .copyDirectory('public/fonts', environment.folder + '/wwwroot/fonts')
-      .copyDirectory('public/images',environment.folder + '/wwwroot/images')
-      .copyDirectory('public/js', environment.folder + '/wwwroot/js')
-      .copyDirectory('public/svg',environment.folder + '/wwwroot/svg')
-      .copy('public/favicon.ico', environment.folder + '/wwwroot/favicon.ico')
-      .copy('public/index.html', environment.folder + '/Views/Home/Index.cshtml' );
-      //.copy('public/pdf',environment.folder + '/wwwroot/pdf')
-}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -2,6 +2,8 @@ let mix = require('laravel-mix');
 let SVGSpritemapPlugin = require('svg-spritemap-webpack-plugin');
 let frontendImports = require('./resources/js/frontend-imports');
 const environment = require('./resources/js/environment.js');
+const criticalPath = require('./resources/js/critical-path');
+const postProd = require('./resources/js/post-prod');
 
 const httpRegex = 'http:\\/\\/|https:\\/\\/';
 const projectProxy = environment.domain.replace(new RegExp(httpRegex), '');
@@ -124,10 +126,7 @@ mix
         templates: 'public/css/critical/',
         suffix: '',
       },
-      urls: [
-        // urls que temos o html
-        { url: '/', template: 'index' },
-      ],
+      urls: environment.pages,
       dimensions: [
         { width: 375, height: 667 },
         { width: 1024, height: 768 },
@@ -136,6 +135,15 @@ mix
         { width: 1920, height: 1080 },
       ],
       ignore: ['@font-face'],
+    })
+    .then(() => {
+
+      if (mix.inProduction()) {
+
+        mix.copyDirectory('resources/html', 'public');
+        postProd.generate(environment.pages);
+        criticalPath.generate(environment.pages);
+      }
     });
 
 /*


### PR DESCRIPTION
- Após contato com o backend, foi requisitado que o style do
critical-css que está na public/html* deveria conter @@ na nomeação dos
at-rules, com isso foi efetuado o novo ajuste que adiciona o @@, e
também foi realizado isolamento dos scripts para ser chamado somente no
webpack do projeto, assim o npm run prod ou npm run production vai
executar os script do critical-css e post-prod.